### PR TITLE
Add unit test for componentNameWizard()

### DIFF
--- a/cmd/configschema/configwiz/configwiz/pipelines.go
+++ b/cmd/configschema/configwiz/configwiz/pipelines.go
@@ -113,9 +113,11 @@ type rpe struct {
 }
 
 func componentListWizard(pr indentingPrinter, componentGroup string, componentNames []string) (out []string) {
+	io := clio{printLine, readline}
+	p := io.newIndentingPrinter(1)
 	for {
 		pr.println(fmt.Sprintf("Current %ss: [%s]", componentGroup, strings.Join(out, ", ")))
-		key, name := componentNameWizard(pr, componentGroup, componentNames)
+		key, name := componentNameWizard(io, p, componentGroup, componentNames)
 		if key == "" {
 			break
 		}
@@ -127,24 +129,26 @@ func componentListWizard(pr indentingPrinter, componentGroup string, componentNa
 	return
 }
 
-func componentNameWizard(pr indentingPrinter, componentType string, componentNames []string) (string, string) {
+func componentNameWizard(io clio, pr indentingPrinter2, componentType string, componentNames []string) (string, string) {
 	pr.println(fmt.Sprintf("Add %s (enter to skip)", componentType))
 	for i, name := range componentNames {
 		pr.println(fmt.Sprintf("%d: %s", i, name))
 	}
 	pr.print("> ")
-	choice := readline("")
+	choice := io.read("")
 	if choice == "" {
 		return "", ""
 	}
 	i, _ := strconv.Atoi(choice)
 	if i < 0 || i > len(componentNames)-1 {
-		fmt.Println(invalidMsg)
-		return componentNameWizard(pr, componentType, componentNames)
+		pr.level--
+		pr.println(invalidMsg)
+		pr.level++
+		return componentNameWizard(io, pr, componentType, componentNames)
 	}
 	key := componentNames[i]
 	pr.print(fmt.Sprintf("%s %s extended name (optional) > ", key, componentType))
-	return key, readline("")
+	return key, io.read("")
 }
 
 type receiverFactoryTest func(factory component.ReceiverFactory) bool

--- a/cmd/configschema/configwiz/configwiz/pipelines_test.go
+++ b/cmd/configschema/configwiz/configwiz/pipelines_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configwiz
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var compNames = []string{"comp1", "comp2", "comp3"}
+
+const compType = "test"
+const compTypeE = "testE"
+
+type fakeReaderPipe struct {
+	userInput []string
+	input     int
+}
+
+func (r *fakeReaderPipe) read(defaultVal string) string {
+	out := r.userInput[r.input]
+	if r.input < len(r.userInput)-1 {
+		r.input++
+	}
+	return out
+}
+
+// Testing ComponentNameWizard()
+func TestComponentNameWizardEmpty(t *testing.T) {
+	w := fakeWriter{}
+	r := fakeReader{}
+	io := clio{w.write, r.read}
+	pr := io.newIndentingPrinter(1)
+	out, val := componentNameWizard(io, pr, compType, compNames)
+	expected := buildNameWizard("", compType, compNames)
+	assert.Equal(t, "", out)
+	assert.Equal(t, "", val)
+	assert.Equal(t, expected, w.programOutput)
+}
+
+func TestComponentNameWizardExtended(t *testing.T) {
+	w := fakeWriter{}
+	r := fakeReader{"0"}
+	io := clio{w.write, r.read}
+	pr := io.newIndentingPrinter(1)
+	out, val := componentNameWizard(io, pr, compType, compNames)
+	expected := buildNameWizard("", compType, compNames)
+	tab := strings.Repeat(" ", 4)
+	expected += fmt.Sprintf("%s%s %s extended name (optional) > ", tab, out, compType)
+	assert.Equal(t, compNames[0], out)
+	assert.Equal(t, val, "0")
+	assert.Equal(t, expected, w.programOutput)
+}
+
+func TestComponentNameWizardError(t *testing.T) {
+	w := fakeWriter{}
+	r := fakeReaderPipe{[]string{"-1", ""}, 0}
+	io := clio{w.write, r.read}
+	pr := io.newIndentingPrinter(1)
+	out, val := componentNameWizard(io, pr, compTypeE, compNames)
+	expected := buildNameWizard("", compTypeE, compNames)
+	expected += "Invalid input. Try again.\n"
+	expected = buildNameWizard(expected, compTypeE, compNames)
+	assert.Equal(t, "", out)
+	assert.Equal(t, "", val)
+	assert.Equal(t, expected, w.programOutput)
+}
+
+// returns componentNameWizard() output, a list of all components
+func buildNameWizard(prefix string, compType string, compNames []string) string {
+	tabSize := 4
+	tab := strings.Repeat(" ", tabSize)
+	expected := fmt.Sprintf("%sAdd %s (enter to skip)\n", tab, compType)
+	for i := 0; i < len(compNames); i++ {
+		expected += fmt.Sprintf("%s%d: %s\n", tab, i, compNames[i])
+	}
+	expected += tab + "> "
+	return prefix + expected
+}

--- a/cmd/configschema/configwiz/configwiz/printer.go
+++ b/cmd/configschema/configwiz/configwiz/printer.go
@@ -51,10 +51,6 @@ func (p indentingPrinter) println(s string) {
 	p.doPrint(s, "%s%s\n")
 }
 
-func (p indentingPrinter) print(s string) {
-	p.doPrint(s, "%s%s")
-}
-
 func (p indentingPrinter) doPrint(s string, frmt string) {
 	const tabSize = 4
 	indent := p.level * tabSize


### PR DESCRIPTION
**Description:** 
Adding Test: Wrote tests for ComponentNameWizard()
Removal : removed indentingPrinter.Print() to clear up linter errors

**Testing:** 
Test written for no inputs, one input, and an invalid input.
